### PR TITLE
Showbugfix bug

### DIFF
--- a/backend/apps/tracker/routes.py
+++ b/backend/apps/tracker/routes.py
@@ -56,7 +56,7 @@ async def log_bug_fix(
         return {"detail": "Bug Updated"}
 
 
-@router.delete("/bug/{bug_id}", status_code=200)
+@router.delete("/bug/{bug_id}", status_code=204)
 async def delete_bug(bug_id, request: Request, user=Depends(credentials)):
     try:
         result = await request.app.mongodb["bug_journal"].delete_one(
@@ -68,7 +68,6 @@ async def delete_bug(bug_id, request: Request, user=Depends(credentials)):
         # deleted_count comes directly from motor library
         # ref https://pymongo.readthedocs.io/en/stable/api/pymongo/results.html
         if result.deleted_count < 1:
-            print("got here")
             raise HTTPException(status_code=404, detail="Bug not found check id")
 
         return {"detail": "Bug Deleted"}

--- a/frontend/src/adapters.js
+++ b/frontend/src/adapters.js
@@ -8,6 +8,7 @@ const loginUrl = apiURL + 'user/login'
 const logoutUrl = apiURL + 'user/logout'
 
 const buglogURL = apiURL + 'log/buglog'
+const bugURL = apiURL + 'log/bug/'
 
 // CHECK LOGIN STATUS
 export const getCurrentUser = async () => {
@@ -63,5 +64,16 @@ export const getLogs = async () => {
     return log
   } catch (err) {
     console.log(err.response.data.detail)
+  }
+}
+
+export const deleteBug = async (id) => {
+  try {
+    const url = bugURL + id
+    console.log(url)
+    const res = await axios.delete((bugURL + id), { withCredentials: true })
+    return res
+  } catch (err) {
+    console.log(console.log(err.message))
   }
 }

--- a/frontend/src/components/control/BugEditor/Logger.jsx
+++ b/frontend/src/components/control/BugEditor/Logger.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function Logger () {
+  return (
+    <div />
+  )
+}

--- a/frontend/src/components/control/BugLog/Bug.jsx
+++ b/frontend/src/components/control/BugLog/Bug.jsx
@@ -1,9 +1,16 @@
 import React, { useState } from 'react'
 import CodeBlock from './CodeBlock'
-import { Container, BugBar, Indicator, BugTitle, DateCreated } from '../../style/BugLog/BugStyles'
+import { Container, BugBar, Indicator, BugTitle, BugDelete, DateCreated } from '../../style/BugLog/BugStyles'
+import { deleteBug } from '../../../adapters'
 
-export default function Bug ({ entry }) {
+export default function Bug ({ entry, displayLog }) {
   const [showCode, setShowCode] = useState(false)
+
+  const bugDelete = async () => {
+    const res = await deleteBug(entry._id)
+    console.log(res)
+    displayLog()
+  }
 
   const displayCode = () => {
     setShowCode(!showCode)
@@ -15,6 +22,7 @@ export default function Bug ({ entry }) {
         <Indicator status={entry.is_fixed} />
         <BugTitle>{`${entry.app} | ${entry.error_type} (${entry.language})`}</BugTitle>
         <DateCreated>{entry.created_date}</DateCreated>
+        <BugDelete onClick={bugDelete}><b>X</b></BugDelete>
       </BugBar>
       <CodeBlock code={entry.init_code} language={entry.language} showCode={showCode} />
     </Container>

--- a/frontend/src/components/control/BugLog/Bug.jsx
+++ b/frontend/src/components/control/BugLog/Bug.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
-import CodeBlock from './CodeBlock'
 import { Container, BugBar, Indicator, BugTitle, BugDelete, DateCreated } from '../../style/BugLog/BugStyles'
 import { deleteBug } from '../../../adapters'
+import BugCode from './BugCode'
 
 export default function Bug ({ entry, displayLog }) {
   const [showCode, setShowCode] = useState(false)
@@ -24,7 +24,7 @@ export default function Bug ({ entry, displayLog }) {
         <DateCreated>{entry.created_date}</DateCreated>
         <BugDelete onClick={bugDelete}><b>X</b></BugDelete>
       </BugBar>
-      <CodeBlock code={entry.init_code} language={entry.language} showCode={showCode} />
+      <BugCode entry={entry} showCode={showCode} />
     </Container>
   )
 }

--- a/frontend/src/components/control/BugLog/Bug.jsx
+++ b/frontend/src/components/control/BugLog/Bug.jsx
@@ -17,8 +17,8 @@ export default function Bug ({ entry, displayLog }) {
   }
 
   return (
-    <Container showCode={showCode} onClick={displayCode} status={entry.is_fixed}>
-      <BugBar>
+    <Container showCode={showCode} status={entry.is_fixed}>
+      <BugBar onClick={displayCode}>
         <Indicator status={entry.is_fixed} />
         <BugTitle>{`${entry.app} | ${entry.error_type} (${entry.language})`}</BugTitle>
         <DateCreated>{entry.created_date}</DateCreated>

--- a/frontend/src/components/control/BugLog/BugCode.jsx
+++ b/frontend/src/components/control/BugLog/BugCode.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Explanation } from '../../style/BugLog/CodeBlockStyles'
+import CodeBlock from './CodeBlock'
+
+export default function BugCode ({ entry, showCode }) {
+  if (entry.is_fixed) {
+    return (
+      <>
+        <CodeBlock code={entry.init_code} language={entry.language} showCode={showCode} />
+        <Explanation>{entry.explanation}</Explanation>
+        <CodeBlock code={entry.fixed_code} language={entry.language} showCode={showCode} />
+      </>
+
+    )
+  }
+  return (
+    <CodeBlock code={entry.init_code} language={entry.language} showCode={showCode} />
+  )
+}

--- a/frontend/src/components/control/BugLog/BugCode.jsx
+++ b/frontend/src/components/control/BugLog/BugCode.jsx
@@ -3,6 +3,10 @@ import { Explanation } from '../../style/BugLog/CodeBlockStyles'
 import CodeBlock from './CodeBlock'
 
 export default function BugCode ({ entry, showCode }) {
+  if (showCode === false) {
+    return null
+  }
+
   if (entry.is_fixed) {
     return (
       <>

--- a/frontend/src/components/control/BugLog/BugLog.jsx
+++ b/frontend/src/components/control/BugLog/BugLog.jsx
@@ -21,7 +21,7 @@ export default function BugLog () {
         <SectionTitle>Logs</SectionTitle>
         <Log>
           {buglog.map((entry) => {
-            return (<Bug key={entry._id} entry={entry} />)
+            return (<Bug key={entry._id} entry={entry} displayLog={displayLog} />)
           })}
         </Log>
       </LogContainer>

--- a/frontend/src/components/control/BugLog/CodeBlock.jsx
+++ b/frontend/src/components/control/BugLog/CodeBlock.jsx
@@ -9,10 +9,6 @@ export default function CodeBlock ({ code, language, showCode }) {
     Prism.highlightAll()
   }, [showCode])
 
-  if (showCode === false) {
-    return null
-  }
-
   return (
     <CodeDiv className='Code'>
       <CodePre className={`language-${language.toLowerCase()}`}>

--- a/frontend/src/components/control/Main.jsx
+++ b/frontend/src/components/control/Main.jsx
@@ -4,7 +4,11 @@ import BugLog from './BugLog/BugLog'
 
 export default function Main ({ user }) {
   if (user) {
-    return (<BugLog />)
+    return (
+      <>
+        <BugLog />
+      </>
+    )
   }
 
   return (<StyledMain>Home World</StyledMain>)

--- a/frontend/src/components/style/BugLog/BugLogStyles.jsx
+++ b/frontend/src/components/style/BugLog/BugLogStyles.jsx
@@ -23,6 +23,7 @@ export const Log = styled.div`
   margin: 5px;
   align-self: flex-end;
   width: 90%;
+  min-height: 70vh;
   background: #F4ECE7;
   border-color: #1b1b1b;
   border-style: solid;

--- a/frontend/src/components/style/BugLog/BugStyles.jsx
+++ b/frontend/src/components/style/BugLog/BugStyles.jsx
@@ -35,7 +35,7 @@ export const BugDelete = styled.button`
   width: 100%;
   background: #ac0404;
   color: black;
-  font-size: 20px;
+  font-size: px;
 `
 
 // will add styles later

--- a/frontend/src/components/style/BugLog/BugStyles.jsx
+++ b/frontend/src/components/style/BugLog/BugStyles.jsx
@@ -25,9 +25,17 @@ export const Container = styled.div`
 
 export const BugBar = styled.div`
   display: grid;
-  grid-template-columns: 5% 80% 15%;
+  grid-template-columns: 5% 80% 10% 5%;
   justify-items: center;
   align-items: center;
+`
+
+export const BugDelete = styled.button`
+  height: 100%;
+  width: 100%;
+  background: #ac0404;
+  color: black;
+  font-size: 20px;
 `
 
 // will add styles later

--- a/frontend/src/components/style/BugLog/CodeBlockStyles.jsx
+++ b/frontend/src/components/style/BugLog/CodeBlockStyles.jsx
@@ -7,3 +7,7 @@ export const CodeDiv = styled.div`
 export const CodePre = styled.pre`
   border-radius: 5px 5px 5px 25px;
 `
+export const Explanation = styled.div`
+  font-size: 16px;
+  margin: 15px 0px 3px 30px
+`


### PR DESCRIPTION
Bug fixes are now shown below the init code. Created new container for code blocks to allow dynamic creation of 1 or 2 codeblocks depending on the status of the bug.  Moved the showCode function back to bug bar to allow the user to copy or click on code text if needed.  