### PR TITLE
Datetimebug

### DIFF
--- a/backend/apps/tracker/models.py
+++ b/backend/apps/tracker/models.py
@@ -6,7 +6,7 @@ import uuid
 # Model used to log bugs
 class BugIn(BaseModel):
     id: str = Field(default_factory=uuid.uuid4, alias="_id")
-    created_date: str = datetime.utcnow().strftime("%m/%d/%Y, %H:%M:%S")
+    created_date: datetime = Field(default_factory=datetime.utcnow)
     app: str
     language: str
     error_type: str

--- a/backend/apps/tracker/routes.py
+++ b/backend/apps/tracker/routes.py
@@ -56,7 +56,7 @@ async def log_bug_fix(
         return {"detail": "Bug Updated"}
 
 
-@router.delete("/bug/{bug_id}", status_code=204)
+@router.delete("/bug/{bug_id}", status_code=200)
 async def delete_bug(bug_id, request: Request, user=Depends(credentials)):
     try:
         result = await request.app.mongodb["bug_journal"].delete_one(
@@ -70,4 +70,4 @@ async def delete_bug(bug_id, request: Request, user=Depends(credentials)):
         if result.deleted_count < 1:
             raise HTTPException(status_code=404, detail="Bug not found check id")
 
-        return {"detail": "Bug Deleted"}
+        return {"detail": "Bug Deleted""%m/%d/%Y, %H:%M:%S"}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4869,6 +4869,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
     "axios": "^0.21.1",
+    "dayjs": "^1.10.4",
     "prismjs": "^1.23.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/src/components/control/BugLog/Bug.jsx
+++ b/frontend/src/components/control/BugLog/Bug.jsx
@@ -1,10 +1,24 @@
 import React, { useState } from 'react'
+import * as dayjs from 'dayjs'
+import * as utc from 'dayjs/plugin/utc'
 import { Container, BugBar, Indicator, BugTitle, BugDelete, DateCreated } from '../../style/BugLog/BugStyles'
 import { deleteBug } from '../../../adapters'
 import BugCode from './BugCode'
 
+dayjs.extend(utc)
+
 export default function Bug ({ entry, displayLog }) {
   const [showCode, setShowCode] = useState(false)
+
+  function formatDate (datetime) {
+    const utcDatetime = dayjs(datetime)
+    const offset = utcDatetime.utcOffset()
+    const userTZTime = utcDatetime.add(offset, 'm')
+    const newDateTime = userTZTime.format('MM/DD/YYYY HH:mm')
+    return newDateTime
+  }
+
+  const createdDate = formatDate(entry.created_date)
 
   const bugDelete = async () => {
     const res = await deleteBug(entry._id)
@@ -21,7 +35,7 @@ export default function Bug ({ entry, displayLog }) {
       <BugBar onClick={displayCode}>
         <Indicator status={entry.is_fixed} />
         <BugTitle>{`${entry.app} | ${entry.error_type} (${entry.language})`}</BugTitle>
-        <DateCreated>{entry.created_date}</DateCreated>
+        <DateCreated>{createdDate}</DateCreated>
         <BugDelete onClick={bugDelete}><b>X</b></BugDelete>
       </BugBar>
       <BugCode entry={entry} showCode={showCode} />

--- a/frontend/src/components/style/BugLog/BugStyles.jsx
+++ b/frontend/src/components/style/BugLog/BugStyles.jsx
@@ -42,4 +42,6 @@ export const BugDelete = styled.button`
 export const BugTitle = styled.h3`
 `
 export const DateCreated = styled.h5`
+  text-align: right;
+  margin-right: 5px;
 `

--- a/frontend/src/components/style/BugLog/CodeBlockStyles.jsx
+++ b/frontend/src/components/style/BugLog/CodeBlockStyles.jsx
@@ -9,5 +9,5 @@ export const CodePre = styled.pre`
 `
 export const Explanation = styled.div`
   font-size: 16px;
-  margin: 15px 0px 3px 30px
+  margin: 15px 0px 3px 30px;
 `


### PR DESCRIPTION
Bug caused backend to stamp new logs at the time the server was started, and didn't display the bugs in the correct format or in the user's local time.  Added dayjs library to handle date parsing and formatting.  